### PR TITLE
Add function that converts a qobj to QuantumCircuit (#877)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,8 @@ Added
 - New interactive visualizations (#765).
 - Added option to reverse the qubit order when plotting a circuit. (#762, #786)
 - Jupyter notebook magic function qiskit_job_status (#734).
+- Add a new function ``qobj_to_circuits`` to convert a Qobj object to
+  a list of QuantumCircuit objects (#877)
 
 Changed
 -------

--- a/qiskit/wrapper/__init__.py
+++ b/qiskit/wrapper/__init__.py
@@ -18,4 +18,4 @@ refer to the documentation of each component and use them separately.
 from ._wrapper import (available_backends, local_backends, remote_backends,
                        get_backend, compile, execute, register, unregister,
                        registered_providers, load_qasm_string, load_qasm_file,
-                       least_busy, store_credentials)
+                       least_busy, store_credentials, qobj_to_circuits)

--- a/qiskit/wrapper/_wrapper.py
+++ b/qiskit/wrapper/_wrapper.py
@@ -364,3 +364,24 @@ def load_qasm_file(qasm_file, name=None,
         QISKitError: if the file cannot be read.
     """
     return circuit_from_qasm_file(qasm_file, name, basis_gates)
+
+
+def qobj_to_circuits(qobj):
+    """Return a list of QuantumCircuit object(s) from a qobj
+
+    Args:
+        qobj (Qobj): The Qobj object to convert to QuantumCircuits
+    Returns:
+        list: A list of QuantumCircuit objects from the qobj
+
+    """
+    if qobj.experiments:
+        circuits = []
+        for x in qobj.experiments:
+            if hasattr(x.header, 'compiled_circuit_qasm'):
+                circuits.append(
+                    load_qasm_string(x.header.compiled_circuit_qasm))
+        return circuits
+    # TODO(mtreinish): add support for converting a qobj if the qasm isn't
+    # embedded in the header
+    return None

--- a/test/python/test_wrapper.py
+++ b/test/python/test_wrapper.py
@@ -11,10 +11,12 @@
 import logging
 import unittest
 
+from qiskit import compile as qcompile
 import qiskit.wrapper
 from qiskit import QISKitError
 from qiskit import QuantumRegister, ClassicalRegister, QuantumCircuit
 from qiskit.backends.ibmq import IBMQProvider
+from qiskit.qobj import Qobj
 from qiskit.wrapper import registered_providers, execute
 from ._mockutils import DummyProvider
 from .common import QiskitTestCase, requires_qe_access
@@ -140,6 +142,34 @@ class TestWrapper(QiskitTestCase):
             with self.subTest(backend_name=backend_name):
                 result = execute(self.circuit, 'local_qasm_simulator').result()
                 self.assertIsNotNone(result.get_ran_qasm(self.circuit.name))
+
+    def test_qobj_to_circuits_single(self):
+        """Check that qobj_to_circuits's result matches the qobj ini."""
+        backend = 'local_qasm_simulator'
+        qobj_in = qcompile(self.circuit, backend, skip_transpiler=True)
+        out_circuit = qiskit.wrapper.qobj_to_circuits(qobj_in)
+        self.assertEqual(out_circuit[0].qasm(), self.circuit.qasm())
+
+    def test_qobj_to_circuits_multiple(self):
+        """Check that qobj_to_circuits's result with multiple circuits"""
+        backend = 'local_qasm_simulator'
+        qreg1 = QuantumRegister(2)
+        qreg2 = QuantumRegister(3)
+        creg1 = ClassicalRegister(2)
+        creg2 = ClassicalRegister(2)
+        circuit_b = QuantumCircuit(qreg1, qreg2, creg1, creg2)
+        circuit_b.x(qreg1)
+        circuit_b.h(qreg2)
+        circuit_b.measure(qreg1, creg1)
+        circuit_b.measure(qreg2[0], creg2[1])
+        qobj = qcompile([self.circuit, circuit_b], backend, skip_transpiler=True)
+        qasm_list = [x.qasm() for x in qiskit.wrapper.qobj_to_circuits(qobj)]
+        self.assertEqual(qasm_list, [self.circuit.qasm(), circuit_b.qasm()])
+
+    def test_qobj_to_circuits_with_qobj_no_qasm(self):
+        """Verify that qobj_to_circuits returns None without QASM."""
+        qobj = Qobj('abc123', {}, {}, {})
+        self.assertIsNone(qiskit.wrapper.qobj_to_circuits(qobj))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
* Add function that converts a qobj to QuantumCircuit

This commit adds a new function to convert a qobj to a list of quantum
circuit objects. Right now it only works with qobj that have the qasm
embedded in the header. If the qobj input doesn't have the qasm in the
header it will just return None.

Fixes #823

* Fix review comments

This commit makes the adjustments based on code review.

* tweaking function name and making test more complex

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary



### Details and comments


